### PR TITLE
removing tincan role

### DIFF
--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -12,7 +12,6 @@ Capistrano::Configuration.instance.load do
   _cset(:tincanctl_cmd) { "#{fetch(:bundle_cmd, 'bundle')} exec tincanctl" }
 
   _cset(:tincan_timeout) { 10 }
-  _cset(:tincan_role) { :app }
   _cset(:tincan_processes) { 1 }
 
   if fetch(:tincan_default_hooks)

--- a/lib/capistrano/tincan/version.rb
+++ b/lib/capistrano/tincan/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Tincan
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end


### PR DESCRIPTION
I've removed the tincan_role capistrano role, this will now be defined within the application itself so we have more control over where we want this running. 